### PR TITLE
Hopefully fixes linking errors on Windows, other changes.

### DIFF
--- a/cmake/macros/TargetOpus.cmake
+++ b/cmake/macros/TargetOpus.cmake
@@ -5,7 +5,7 @@
 #  Distributed under the Apache License, Version 2.0.
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 #
-macro(TARGET_opus)
+macro(TARGET_OPUS)
     if (ANDROID)
         # no idea if this is correct
         target_link_libraries(${TARGET_NAME})

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -39,10 +39,10 @@ if (NOT SERVER_ONLY AND NOT ANDROID)
 endif()
 
 # server-side plugins
-set(DIR "pcmCodec")
-add_subdirectory(${DIR})
-set(DIR "hifiCodec")
-add_subdirectory(${DIR})
+# set(DIR "pcmCodec")
+# add_subdirectory(${DIR})
+# set(DIR "hifiCodec")
+# add_subdirectory(${DIR})
 set(DIR "opusCodec")
 add_subdirectory(${DIR})
 

--- a/plugins/opusCodec/CMakeLists.txt
+++ b/plugins/opusCodec/CMakeLists.txt
@@ -9,6 +9,7 @@
 set(TARGET_NAME opusCodec)
 setup_hifi_client_server_plugin()
 link_hifi_libraries(shared audio plugins)
+target_opus()
 
 if (BUILD_SERVER)
   install_beside_console()


### PR DESCRIPTION
This PR hopefully fixes linking errors for the opusCodec on Windows. It also disables the hifiCodec and pcmCodec projects, in an attempt to make sure that opus is always used. Also contains a cosmetic change to TargetOpus.cmake.